### PR TITLE
major(auto-release): stop automatically publishing a release after me…

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -8,4 +8,4 @@ jobs:
     steps:
       - uses: cloudposse/github-action-auto-release@866180107092a985cadc864c327cb555c2331e6f # v2
         with:
-          publish: true
+          publish: false


### PR DESCRIPTION
## **User description**
…rge to main


___

## **Type**
enhancement


___

## **Description**
- This PR disables the automatic publishing of releases upon merging to the main branch by setting the `publish` attribute to `false` in the auto-release GitHub Action workflow.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auto-release.yml</strong><dd><code>Disable Automatic Publishing of Releases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
.github/workflows/auto-release.yml

<li>Changed <code>publish</code> from <code>true</code> to <code>false</code> to stop automatic publishing of <br>releases.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/github-workflows/pull/31/files#diff-5a93af5afcdcd2bdc566f58652f8af7fec28b2d02acb9bec8ee97e9334362731">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

