### PR TITLE
Feature/argo tags ci/add retries

### DIFF
--- a/.github/workflows/argocd-tags-ci.yml
+++ b/.github/workflows/argocd-tags-ci.yml
@@ -80,6 +80,7 @@ jobs:
       working-directory: ./${{ inputs.DEPLOYMENT_CONFIGS_REPO }}
       run: |
         set -e
+        git pull --rebase
         TAG=${{ steps.TagRelease.outputs.TAG || steps.TagNoRelease.outputs.TAG }}
         DEPLOYMENT_CONFIGS_APP_NAME=${{ inputs.DEPLOYMENT_CONFIGS_APP_NAME || github.event.repository.name }}
         yq -i ".image.tag = \"$TAG\"" ./apps/$DEPLOYMENT_CONFIGS_APP_NAME/envs/${{ inputs.ENV }}/values.yaml

--- a/.github/workflows/argocd-tags-ci.yml
+++ b/.github/workflows/argocd-tags-ci.yml
@@ -77,18 +77,24 @@ jobs:
         echo "TAG=$TAG" >> $GITHUB_OUTPUT
 
     - name: Update Image Tag
-      working-directory: ./${{ inputs.DEPLOYMENT_CONFIGS_REPO }}
-      run: |
-        set -e
-        git pull --rebase
-        TAG=${{ steps.TagRelease.outputs.TAG || steps.TagNoRelease.outputs.TAG }}
-        DEPLOYMENT_CONFIGS_APP_NAME=${{ inputs.DEPLOYMENT_CONFIGS_APP_NAME || github.event.repository.name }}
-        yq -i ".image.tag = \"$TAG\"" ./apps/$DEPLOYMENT_CONFIGS_APP_NAME/envs/${{ inputs.ENV }}/values.yaml
-        git config --global --add --bool push.autoSetupRemote true
-        git config --local user.email "automated-github-action@glueops.dev"
-        git config --local user.name "GlueOps bot"
-        git add -A
-        git commit -m "${{ github.event.repository.name }}: updating ${{ inputs.ENV }} tag to $TAG, by ${{ github.actor }}"
+      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
+      with:
+        shell: bash
+        retry_on: error
+        timeout_minutes: 2
+        max_attempts: 3
+        command: |
+          set -e
+          cd ./${{ inputs.DEPLOYMENT_CONFIGS_REPO }}
+          git pull --rebase
+          TAG=${{ steps.TagRelease.outputs.TAG || steps.TagNoRelease.outputs.TAG }}
+          DEPLOYMENT_CONFIGS_APP_NAME=${{ inputs.DEPLOYMENT_CONFIGS_APP_NAME || github.event.repository.name }}
+          yq -i ".image.tag = \"$TAG\"" ./apps/$DEPLOYMENT_CONFIGS_APP_NAME/envs/${{ inputs.ENV }}/values.yaml
+          git config --global --add --bool push.autoSetupRemote true
+          git config --local user.email "automated-github-action@glueops.dev"
+          git config --local user.name "GlueOps bot"
+          git add -A
+          git commit -m "${{ github.event.repository.name }}: updating ${{ inputs.ENV }} tag to $TAG, by ${{ github.actor }}"
 
     - name: Create PR if Desired
       if: ${{ inputs.CREATE_PR }}

--- a/.github/workflows/argocd-tags-ci.yml
+++ b/.github/workflows/argocd-tags-ci.yml
@@ -77,18 +77,24 @@ jobs:
         echo "TAG=$TAG" >> $GITHUB_OUTPUT
 
     - name: Update Image Tag
-      working-directory: ./${{ inputs.DEPLOYMENT_CONFIGS_REPO }}
-      run: |
-        set -e
-        git pull --rebase
-        TAG=${{ steps.TagRelease.outputs.TAG || steps.TagNoRelease.outputs.TAG }}
-        DEPLOYMENT_CONFIGS_APP_NAME=${{ inputs.DEPLOYMENT_CONFIGS_APP_NAME || github.event.repository.name }}
-        yq -i ".image.tag = \"$TAG\"" ./apps/$DEPLOYMENT_CONFIGS_APP_NAME/envs/${{ inputs.ENV }}/values.yaml
-        git config --global --add --bool push.autoSetupRemote true
-        git config --local user.email "automated-github-action@glueops.dev"
-        git config --local user.name "GlueOps bot"
-        git add -A
-        git commit -m "${{ github.event.repository.name }}: updating ${{ inputs.ENV }} tag to $TAG, by ${{ github.actor }}"
+      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
+      with:
+        shell: bash
+        retry_on: error
+        timeout_minutes: 2
+        max_attempts: 3
+        working-directory: ./${{ inputs.DEPLOYMENT_CONFIGS_REPO }}
+        command: |
+          set -e
+          git pull --rebase
+          TAG=${{ steps.TagRelease.outputs.TAG || steps.TagNoRelease.outputs.TAG }}
+          DEPLOYMENT_CONFIGS_APP_NAME=${{ inputs.DEPLOYMENT_CONFIGS_APP_NAME || github.event.repository.name }}
+          yq -i ".image.tag = \"$TAG\"" ./apps/$DEPLOYMENT_CONFIGS_APP_NAME/envs/${{ inputs.ENV }}/values.yaml
+          git config --global --add --bool push.autoSetupRemote true
+          git config --local user.email "automated-github-action@glueops.dev"
+          git config --local user.name "GlueOps bot"
+          git add -A
+          git commit -m "${{ github.event.repository.name }}: updating ${{ inputs.ENV }} tag to $TAG, by ${{ github.actor }}"
 
     - name: Create PR if Desired
       if: ${{ inputs.CREATE_PR }}

--- a/.github/workflows/argocd-tags-ci.yml
+++ b/.github/workflows/argocd-tags-ci.yml
@@ -83,13 +83,12 @@ jobs:
         retry_on: error
         timeout_minutes: 2
         max_attempts: 3
-        working-directory: ./${{ inputs.DEPLOYMENT_CONFIGS_REPO }}
         command: |
           set -e
           git pull --rebase
           TAG=${{ steps.TagRelease.outputs.TAG || steps.TagNoRelease.outputs.TAG }}
           DEPLOYMENT_CONFIGS_APP_NAME=${{ inputs.DEPLOYMENT_CONFIGS_APP_NAME || github.event.repository.name }}
-          yq -i ".image.tag = \"$TAG\"" ./apps/$DEPLOYMENT_CONFIGS_APP_NAME/envs/${{ inputs.ENV }}/values.yaml
+          yq -i ".image.tag = \"$TAG\"" ./${{ inputs.DEPLOYMENT_CONFIGS_REPO }}/apps/$DEPLOYMENT_CONFIGS_APP_NAME/envs/${{ inputs.ENV }}/values.yaml
           git config --global --add --bool push.autoSetupRemote true
           git config --local user.email "automated-github-action@glueops.dev"
           git config --local user.name "GlueOps bot"

--- a/.github/workflows/argocd-tags-ci.yml
+++ b/.github/workflows/argocd-tags-ci.yml
@@ -77,23 +77,18 @@ jobs:
         echo "TAG=$TAG" >> $GITHUB_OUTPUT
 
     - name: Update Image Tag
-      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
-      with:
-        shell: bash
-        retry_on: error
-        timeout_minutes: 2
-        max_attempts: 3
-        command: |
-          set -e
-          git pull --rebase
-          TAG=${{ steps.TagRelease.outputs.TAG || steps.TagNoRelease.outputs.TAG }}
-          DEPLOYMENT_CONFIGS_APP_NAME=${{ inputs.DEPLOYMENT_CONFIGS_APP_NAME || github.event.repository.name }}
-          yq -i ".image.tag = \"$TAG\"" ./${{ inputs.DEPLOYMENT_CONFIGS_REPO }}/apps/$DEPLOYMENT_CONFIGS_APP_NAME/envs/${{ inputs.ENV }}/values.yaml
-          git config --global --add --bool push.autoSetupRemote true
-          git config --local user.email "automated-github-action@glueops.dev"
-          git config --local user.name "GlueOps bot"
-          git add -A
-          git commit -m "${{ github.event.repository.name }}: updating ${{ inputs.ENV }} tag to $TAG, by ${{ github.actor }}"
+      working-directory: ./${{ inputs.DEPLOYMENT_CONFIGS_REPO }}
+      run: |
+        set -e
+        git pull --rebase
+        TAG=${{ steps.TagRelease.outputs.TAG || steps.TagNoRelease.outputs.TAG }}
+        DEPLOYMENT_CONFIGS_APP_NAME=${{ inputs.DEPLOYMENT_CONFIGS_APP_NAME || github.event.repository.name }}
+        yq -i ".image.tag = \"$TAG\"" ./apps/$DEPLOYMENT_CONFIGS_APP_NAME/envs/${{ inputs.ENV }}/values.yaml
+        git config --global --add --bool push.autoSetupRemote true
+        git config --local user.email "automated-github-action@glueops.dev"
+        git config --local user.name "GlueOps bot"
+        git add -A
+        git commit -m "${{ github.event.repository.name }}: updating ${{ inputs.ENV }} tag to $TAG, by ${{ github.actor }}"
 
     - name: Create PR if Desired
       if: ${{ inputs.CREATE_PR }}


### PR DESCRIPTION
### **PR Type**
enhancement, bug_fix


___

### **Description**
- Added a retry mechanism to the 'Update Image Tag' job in the ArgoCD Tags CI workflow to handle potential errors during the execution.
- The retry action uses `nick-fields/retry` at a specific commit, ensuring stability and reliability.
- Updated the script to include `git pull --rebase` to synchronize with the latest repository state before making changes.
- The retry configuration includes a timeout of 2 minutes and a maximum of 3 attempts.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>argocd-tags-ci.yml</strong><dd><code>Integrate Retry Mechanism and Update Script in ArgoCD Tags CI Workflow</code></dd></summary>
<hr>

.github/workflows/argocd-tags-ci.yml
<li>Integrated retry mechanism using <code>nick-fields/retry</code> action for the <br>'Update Image Tag' job.<br> <li> Added <code>git pull --rebase</code> to ensure the latest changes are incorporated <br>before updating the image tag.<br> <li> Modified the script to run within the retry block to handle potential <br>errors and retries.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/github-workflows/pull/36/files#diff-400dada20851924e24b4da51ea753a8e0fc30c47cf0ef338bb54ca642bc82b6c">+18/-11</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

