### PR TITLE
fix: monorepo by adding DEPLOYMENT_CONFIGS_APP_NAME to the PR name

### DIFF
--- a/.github/workflows/argocd-tags-ci.yml
+++ b/.github/workflows/argocd-tags-ci.yml
@@ -96,6 +96,20 @@ jobs:
           git add -A
           git commit -m "${{ github.event.repository.name }}: updating ${{ inputs.ENV }} tag to $TAG, by ${{ github.actor }}"
 
+
+    # Step to determine the dynamic part of the branch name
+    - name: Set App Name Branch Part
+      id: app_name_part
+      run: |
+        APP_NAME="${{ inputs.DEPLOYMENT_CONFIGS_APP_NAME }}"
+        BRANCH_PART="" # Initialize with an empty string
+        if [ -n "$APP_NAME" ]; then # -n checks if the string is not empty
+          BRANCH_PART="${APP_NAME}-"
+        fi
+        # Set the output named 'dynamic_part'
+        echo "dynamic_part=${BRANCH_PART}" >> "$GITHUB_OUTPUT"
+      shell: bash
+
     - name: Create PR if Desired
       if: ${{ inputs.CREATE_PR }}
       uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
@@ -104,7 +118,7 @@ jobs:
         path: './${{ inputs.DEPLOYMENT_CONFIGS_REPO }}'
         title: '${{ github.event.repository.name }} [${{ inputs.ENV }}] > ${{ steps.TagRelease.outputs.TAG || steps.TagNoRelease.outputs.TAG }}'
         base: ${{ inputs.DEPLOYMENT_CONFIGS_REPO_DEFAULT_BRANCH }}
-        branch: '${{ github.event.repository.name }}/update-${{ inputs.ENV }}-image-tag-${{ steps.TagRelease.outputs.TAG || steps.TagNoRelease.outputs.TAG }}'
+        branch: '${{ github.event.repository.name }}/update-${{ steps.app_name_part.outputs.dynamic_part }}${{ inputs.ENV }}-image-tag-${{ steps.TagRelease.outputs.TAG || steps.TagNoRelease.outputs.TAG }}'
         body: "PR created via CI workflow in [${{ github.repository_owner }}/${{ github.event.repository.name }}](https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}) by [${{ github.actor }}](https://github.com/${{ github.actor }})"
     
     - name: Commit to Default Branch if PR not Desired


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Add dynamic app name prefix to PR branch names in workflow

- Introduce step to set branch name part based on `DEPLOYMENT_CONFIGS_APP_NAME`

- Update PR creation to use dynamic branch naming


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>argocd-tags-ci.yml</strong><dd><code>Dynamic app name prefix for PR branch names in workflow</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/argocd-tags-ci.yml

<li>Added a step to set a dynamic branch name part using <br><code>DEPLOYMENT_CONFIGS_APP_NAME</code><br> <li> Updated PR creation step to use the dynamic branch name part<br> <li> Ensured branch names are prefixed with app name if provided


</details>


  </td>
  <td><a href="https://github.com/GlueOps/github-workflows/pull/79/files#diff-400dada20851924e24b4da51ea753a8e0fc30c47cf0ef338bb54ca642bc82b6c">+15/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>