### PR TITLE
fix: missing hotfix convention

### DIFF
--- a/.github/workflows/glueops-basic-pr-checks.yml
+++ b/.github/workflows/glueops-basic-pr-checks.yml
@@ -34,7 +34,7 @@ jobs:
           conventional-commits: |
             conventional-commits:
               - type: 'fix'
-                nouns: ['fix', 'docs', 'style', 'refactor', 'test', 'chore', 'pref', 'ci', 'chore']
+                nouns: ['fix', 'docs', 'style', 'refactor', 'test', 'chore', 'pref', 'ci', 'chore', 'hotfix']
                 labels: ['patch']
               - type: 'feature'
                 nouns: ['feat']

--- a/.github/workflows/glueops-basic-pr-checks.yml
+++ b/.github/workflows/glueops-basic-pr-checks.yml
@@ -34,7 +34,7 @@ jobs:
           conventional-commits: |
             conventional-commits:
               - type: 'fix'
-                nouns: ['fix', 'docs', 'style', 'refactor', 'test', 'chore', 'pref', 'ci', 'chore', 'hotfix']
+                nouns: ['fix', 'docs', 'style', 'refactor', 'test', 'chore', 'pref', 'ci', 'hotfix']
                 labels: ['patch']
               - type: 'feature'
                 nouns: ['feat']


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add missing 'hotfix' noun to conventional commits configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub PR Workflow"] --> B["Conventional Commits Config"]
  B --> C["Add 'hotfix' noun"]
  C --> D["Enable hotfix labeling"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>glueops-basic-pr-checks.yml</strong><dd><code>Add hotfix to conventional commits configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/glueops-basic-pr-checks.yml

<ul><li>Add 'hotfix' to the list of conventional commit nouns<br> <li> Enable automatic labeling for hotfix commits as 'patch'</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/github-workflows/pull/87/files#diff-8de980440f5c2d5f362b92499b28a9b5fcf5c4eda7eb11e7dcaa4f51ab1c086c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

