### PR TITLE
fix: BREAKING CHANGE to just BREAKING

### DIFF
--- a/.github/workflows/glueops-basic-pr-checks.yml
+++ b/.github/workflows/glueops-basic-pr-checks.yml
@@ -40,7 +40,7 @@ jobs:
                 nouns: ['feat']
                 labels: ['minor','enhancement']
               - type: 'breaking_change'
-                nouns: ['breaking', 'major', 'BREAKING CHANGE']
+                nouns: ['breaking', 'major', 'BREAKING']
                 labels: ['major']
           maintain-labels-not-matched: false
           apply-changes: true


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Update conventional commit configuration for breaking changes

- Change `BREAKING CHANGE` to `BREAKING` in workflow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Workflow Configuration"] --> B["Breaking Change Detection"]
  B --> C["Updated Noun: 'BREAKING'"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>glueops-basic-pr-checks.yml</strong><dd><code>Update breaking change noun configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/glueops-basic-pr-checks.yml

<ul><li>Modified breaking change noun from 'BREAKING CHANGE' to 'BREAKING'<br> <li> Updated conventional-commits configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/github-workflows/pull/93/files#diff-8de980440f5c2d5f362b92499b28a9b5fcf5c4eda7eb11e7dcaa4f51ab1c086c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

