### PR TITLE
fix: Enable allowUpdates in release workflow to prevent false failures

### DIFF
--- a/.github/workflows/bump-version-cut-release.yaml
+++ b/.github/workflows/bump-version-cut-release.yaml
@@ -28,3 +28,4 @@ jobs:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: ${{ steps.tag_version.outputs.new_tag }}
           generateReleaseNotes: true
+          allowUpdates: true


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Enable `allowUpdates` flag in GitHub release workflow

- Prevent false failures when release already exists


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Release Action"] -- "allowUpdates: true" --> B["Prevent Duplicate Release Errors"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bump-version-cut-release.yaml</strong><dd><code>Enable release updates in workflow configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/bump-version-cut-release.yaml

<ul><li>Added <code>allowUpdates: true</code> parameter to release action<br> <li> Allows workflow to update existing releases instead of failing</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/github-workflows/pull/128/files#diff-ace0ab4fca3eb3566772da617fbaa02b7a6f7dda223dbd66334174642354a6bf">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

